### PR TITLE
feat: 在 init 函数参数错误时抛出错误

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,17 @@ import { L2D } from './l2d.js';
 export type { L2D } from './l2d.js';
 export type * from './types.js';
 
-export function init(canvasEl: HTMLCanvasElement | null) {
+/**
+ * Initialize L2D instance
+ * @param canvasEl canvas element
+ * @returns L2D instance
+ */
+export function init(canvasEl: HTMLCanvasElement) {
   if (!canvasEl) {
-    console.error('Target element node not found.');
+    throw new TypeError('Target element node not found.');
+  }
+  if (!(canvasEl instanceof HTMLCanvasElement)) {
+    throw new TypeError('Target element node is not a canvas element.');
   }
   const l2d = new L2D(canvasEl!);
   return l2d;


### PR DESCRIPTION
修改如下:

1. 把 `init` 函数的参数类型定义从 `HTMLCanvasElement | null` 修改为 `HTMLCanvasElement`
2. 在 `init` 函数中检查参数类型, 如果不是一个 `HTMLCanvasElement` 则抛出 `TypeError`