### PR TITLE
docs: 添加 React 使用示例

### DIFF
--- a/docs/guide/case/react.md
+++ b/docs/guide/case/react.md
@@ -9,6 +9,7 @@ function App() {
   const [live2d, setLive2d] = useState<L2D | null>(null);
   const [model, setModel] = useState<Model | null>(null);
 
+  // 初始化 l2d
   useEffect(() => {
     const canvas = document.getElementById('live2d') as HTMLCanvasElement;
     const l2d = init(canvas);
@@ -18,40 +19,26 @@ function App() {
     };
   }, []);
 
+  // 在组件卸载或者 model 变化时销毁 model
+  useEffect(() => {
+    return () => {
+      if (model) {
+        model.destroy();
+      }
+    };
+  }, [model]);
+
   return (
-    <main
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        flexDirection: 'column',
-        gap: '10px',
-        width: '100dvw',
-        height: '100dvh',
-      }}
-    >
-      <div
-        style={{
-          width: '300px',
-          height: '300px',
-          backgroundColor: 'lightblue',
-        }}
-      >
+    <main>
+      <div>
         <canvas id="live2d" />
       </div>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          gap: '10px',
-        }}
-      >
+      <div>
         <button
           onClick={async () => {
             const model = await live2d!.create({
               path: 'https://model.hacxy.cn/HK416-1-normal/model.json',
-              scale: 0.06,
+              scale: 0.1,
             });
             setModel(model);
           }}
@@ -60,10 +47,7 @@ function App() {
           加载模型
         </button>
         <button
-          onClick={() => {
-            model!.destroy();
-            setModel(null);
-          }}
+          onClick={() => setModel(null)}
           disabled={model === null}
         >
           清除模型

--- a/docs/guide/case/react.md
+++ b/docs/guide/case/react.md
@@ -1,1 +1,77 @@
 # 在React中使用
+
+```tsx
+// src/App.tsx
+import { init, type L2D, type Model } from 'l2d';
+import { useEffect, useState } from 'react';
+
+function App() {
+  const [live2d, setLive2d] = useState<L2D | null>(null);
+  const [model, setModel] = useState<Model | null>(null);
+
+  useEffect(() => {
+    const canvas = document.getElementById('live2d') as HTMLCanvasElement;
+    const l2d = init(canvas);
+    setLive2d(l2d);
+    return () => {
+      setLive2d(null);
+    };
+  }, []);
+
+  return (
+    <main
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column',
+        gap: '10px',
+        width: '100dvw',
+        height: '100dvh',
+      }}
+    >
+      <div
+        style={{
+          width: '300px',
+          height: '300px',
+          backgroundColor: 'lightblue',
+        }}
+      >
+        <canvas id="live2d" />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '10px',
+        }}
+      >
+        <button
+          onClick={async () => {
+            const model = await live2d!.create({
+              path: 'https://model.hacxy.cn/HK416-1-normal/model.json',
+              scale: 0.06,
+            });
+            setModel(model);
+          }}
+          disabled={live2d === null || model !== null}
+        >
+          加载模型
+        </button>
+        <button
+          onClick={() => {
+            model!.destroy();
+            setModel(null);
+          }}
+          disabled={model === null}
+        >
+          清除模型
+        </button>
+      </div>
+    </main>
+  );
+}
+
+export default App;
+```


### PR DESCRIPTION
向文档中添加在 React 中使用 l2d 的一个可能实现, 包含实例化 L2D、加载模型、销毁模型

模型使用了 l2d 的 [stackblitz](https://stackblitz.com/edit/vitejs-vite-dye9t3?file=src%2Fmain.ts) 中所用的模型

示例内容在 React 19 + Vite 6 + l2d 0.0.1-alpha.6 中测试无误